### PR TITLE
feat: add generic browser automation and local llm options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Provider for LLM operations (e.g. openai, anthropic, stub)
+LLM_PROVIDER=stub
+# API key for the chosen LLM provider
+LLM_API_KEY=
+# Path to a local model when using llama_cpp or similar
+LLM_MODEL_PATH=
+
+# Amazon credentials
+AMAZON_USERNAME=
+AMAZON_PASSWORD=
+
+# Twitter credentials
+TWITTER_API_KEY=
+TWITTER_API_SECRET=
+TWITTER_ACCESS_TOKEN=
+TWITTER_ACCESS_SECRET=
+
+# Example site credentials (replace EXAMPLE with a service identifier)
+EXAMPLE_SITE_USERNAME=
+EXAMPLE_SITE_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -1,2 +1,88 @@
 # ORALLMAgent
-Agent
+
+Minimal prototype of an autonomous task execution system inspired by projects
+like Manus.  The goal is to demonstrate a clean API surface that can later be
+extended to chat bots, web apps or mobile clients.
+
+## Features
+
+* Accepts natural language instructions via an HTTP API.
+* Asks an LLM to produce an execution plan.
+* Executes the plan step by step using simple tool functions.
+* Built‑in tools for web search, Amazon price lookup, Twitter automation and
+  generic browser control via Playwright.
+* Command line interface with ``!websearch``, ``!amazon``, ``!twitter`` and
+  ``!browse`` commands.
+* After each step the LLM can perform a short reflection.
+* The architecture separates planning, execution and the HTTP layer which makes
+  it easy to integrate the core logic elsewhere.
+
+## Usage
+
+```bash
+pip install -r requirements.txt
+playwright install  # installs browser binaries
+uvicorn main:app --reload
+```
+
+Then send a request:
+
+```bash
+curl -X POST http://localhost:8000/tasks -H "Content-Type: application/json" \
+    -d '{"instruction": "write hello to test.txt"}'
+```
+
+Without an API key the system falls back to deterministic behaviour which keeps
+it functional for local experiments.
+
+### Windows quick start
+
+The repository ships with a PowerShell script that installs Python (via
+``winget``), clones this repository, prepares a virtual environment, installs
+all dependencies and downloads Playwright browser binaries.  Run the following
+from an elevated PowerShell prompt:
+
+```powershell
+Set-ExecutionPolicy Bypass -Scope Process -Force
+./setup.ps1
+```
+
+After setup, start the API using:
+
+```powershell
+./run_agent.ps1
+```
+
+Environment variables such as API keys can be stored in a ``.env`` file.  A
+``.env.example`` template is provided for convenience.  **Never commit real
+credentials to source control.**  Store API keys and passwords in ``.env`` or
+the Windows credential manager.
+
+### Command line usage
+
+The ``cli.py`` helper exposes a very small command interface:
+
+```bash
+python cli.py "!websearch sushi"
+python cli.py "!amazon raspberry pi"
+python cli.py "!twitter tweet hello world"
+python cli.py "!browse https://example.com/login EXAMPLE_SITE_USERNAME EXAMPLE_SITE_PASSWORD"
+```
+
+Twitter commands require API credentials.  Amazon scraping is intended for
+simple experiments and may need adjustments to comply with Amazon's terms of
+service.  Generic browsing uses real browser automation and may trigger
+CAPTCHA or 2FA challenges; the agent will not attempt to bypass them and should
+prompt for manual input when necessary.
+
+### LLM configuration
+
+Set ``LLM_PROVIDER`` in ``.env`` to ``openai``, ``llama_cpp`` or ``stub``.  When
+using local models provide ``LLM_MODEL_PATH`` pointing to the model file.
+
+### Security notes
+
+* Keep `.env` outside version control and restrict file permissions.
+* Prefer Windows Credential Manager for long‑term storage of passwords.
+* Browser automation should respect target site terms of service.  Manual
+  intervention is required for CAPTCHA/2FA challenges.

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,1 @@
+"""Core modules for the ORALLM agent prototype."""

--- a/agent/browser.py
+++ b/agent/browser.py
@@ -1,0 +1,79 @@
+"""Browser automation helpers using Playwright.
+
+This module performs simple login and post-login actions using Playwright.  It
+simulates basic human behaviour with small delays.  **Never hard-code real
+credentials; use environment variables or a credential manager.**
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Dict, List
+
+from playwright.sync_api import sync_playwright
+
+
+def _slow_type(locator, text: str) -> None:
+    """Type ``text`` into ``locator`` with random delays."""
+
+    for ch in text:
+        locator.type(ch, delay=random.randint(50, 150))
+
+
+def login_and_run(url: str, username: str, password: str, actions: List[Dict[str, str]]) -> str:
+    """Log into ``url`` and execute additional ``actions``.
+
+    Parameters
+    ----------
+    url:
+        Login page URL.
+    username/password:
+        Credentials for the site.  They must be supplied securely by the caller.
+    actions:
+        List of dictionaries describing follow-up actions.  Supported keys are
+        ``action`` ("goto"/"click"/"type"/"wait"), ``selector``, ``text`` and
+        ``url``/``ms`` depending on the action.
+    """
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        page.goto(url)
+
+        user = page.query_selector("input[type='email'], input[type='text'][name*='user'], input[name*='email']")
+        pw = page.query_selector("input[type='password']")
+        submit = page.query_selector("button[type='submit'], input[type='submit']")
+        if not user or not pw or not submit:
+            browser.close()
+            return "login form not found; manual intervention required"
+
+        user.click()
+        _slow_type(user, username)
+        pw.click()
+        _slow_type(pw, password)
+        submit.click()
+        page.wait_for_load_state("networkidle")
+
+        for act in actions:
+            kind = act.get("action")
+            if kind == "goto":
+                dest = act.get("url")
+                if dest:
+                    page.goto(dest)
+            elif kind == "click":
+                sel = act.get("selector")
+                if sel and (el := page.query_selector(sel)):
+                    el.click()
+                    page.wait_for_timeout(300)
+            elif kind == "type":
+                sel = act.get("selector")
+                txt = act.get("text", "")
+                if sel and (el := page.query_selector(sel)):
+                    el.click()
+                    _slow_type(el, txt)
+            elif kind == "wait":
+                ms = int(act.get("ms", 1000))
+                page.wait_for_timeout(ms)
+
+        browser.close()
+        return "completed"

--- a/agent/executor.py
+++ b/agent/executor.py
@@ -1,0 +1,34 @@
+"""Plan execution utilities."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+from .llm import LLMClient, Step
+from . import tools
+
+# Mapping from tool names to callables.  New tools can be registered here
+# without having to touch the execution logic itself.
+TOOL_REGISTRY = {
+    "web_search": tools.web_search,
+    "read_file": tools.read_file,
+    "write_file": tools.write_file,
+    "image_generate": tools.image_generate,
+    "browser": tools.browser_automation,
+    "echo": tools.echo,
+}
+
+
+def execute_plan(plan: Iterable[Step], llm: LLMClient) -> List[str]:
+    """Execute *plan* sequentially using *llm* for optional reflection."""
+
+    results: List[str] = []
+    for step in plan:
+        func = TOOL_REGISTRY.get(step.tool)
+        if not func:
+            results.append(f"unknown tool: {step.tool}")
+            continue
+        result = func(**step.args)
+        results.append(result)
+        llm.reflect(result)
+    return results

--- a/agent/llm.py
+++ b/agent/llm.py
@@ -1,0 +1,109 @@
+"""LLM helper utilities.
+
+The real system would talk to OpenAI, Anthropic or a local model.  The
+implementation below keeps the interface but falls back to deterministic
+responses when no API key is provided.  This keeps the prototype fully
+functional in offline environments.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+import os
+
+try:  # Optional import; the package may not be installed.
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - we do not want tests to fail here
+    openai = None  # type: ignore
+
+try:  # Local model backend
+    from llama_cpp import Llama  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    Llama = None  # type: ignore
+
+
+@dataclass
+class Step:
+    """Simple representation of an execution step planned by the LLM."""
+
+    tool: str
+    args: Dict[str, Any]
+    description: str
+
+
+class LLMClient:
+    """Very small wrapper around an LLM provider.
+
+    The client supports ``openai`` for hosted models and ``llama_cpp`` for local
+    execution.  Additional providers can be integrated with minimal changes.
+    """
+
+    def __init__(
+        self,
+        provider: Optional[str] = None,
+        api_key: Optional[str] = None,
+        model_path: Optional[str] = None,
+    ) -> None:
+        self.provider = provider or "stub"
+        self.api_key = api_key or os.getenv("LLM_API_KEY")
+        self.model_path = model_path or os.getenv("LLM_MODEL_PATH")
+        self._model = None
+        if self.provider == "llama_cpp" and self.model_path and Llama is not None:
+            try:
+                self._model = Llama(model_path=self.model_path)
+            except Exception:
+                # Fallback to stub when model loading fails
+                self.provider = "stub"
+
+    # ------------------------------------------------------------------
+    def plan(self, instruction: str) -> List[Step]:
+        """Create a naive execution plan for *instruction*.
+
+        The real implementation would send the request to the configured LLM
+        provider.  If no provider is configured we return a deterministic plan
+        so that the rest of the system can be exercised.
+        """
+
+        if self.provider == "openai" and self.api_key and openai is not None:
+            response = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": f"Plan steps to: {instruction}"}],
+            )
+            plan_text: str = response["choices"][0]["message"]["content"]  # type: ignore[index]
+            return [Step(tool="echo", args={"text": plan_text}, description="raw plan")]
+
+        if self.provider == "llama_cpp" and self._model is not None:
+            out = self._model(f"Plan steps to: {instruction}")
+            plan_text = out["choices"][0]["text"]  # type: ignore[index]
+            return [Step(tool="echo", args={"text": plan_text}, description="raw plan")]
+
+        # Fallback deterministic plan when no provider is configured
+        return [
+            Step(
+                tool="echo",
+                args={"text": f"LLM unavailable. Instruction was: {instruction}"},
+                description="echo fallback",
+            )
+        ]
+
+    # ------------------------------------------------------------------
+    def reflect(self, result: str) -> str:
+        """Allow the LLM to reflect on the latest *result*.
+
+        When the provider is not available we simply return the original
+        result.  This keeps the call synchronous for easier reasoning.
+        """
+
+        if self.provider == "openai" and self.api_key and openai is not None:
+            response = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": f"Reflect on: {result}"}],
+            )
+            return response["choices"][0]["message"]["content"]  # type: ignore[index]
+
+        if self.provider == "llama_cpp" and self._model is not None:
+            out = self._model(f"Reflect on: {result}")
+            return out["choices"][0]["text"]  # type: ignore[index]
+
+        return result

--- a/agent/planner.py
+++ b/agent/planner.py
@@ -1,0 +1,13 @@
+"""High level planning helpers."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .llm import LLMClient, Step
+
+
+def plan_task(instruction: str, llm: LLMClient) -> List[Step]:
+    """Ask *llm* to create a plan for *instruction*."""
+
+    return llm.plan(instruction)

--- a/agent/tools.py
+++ b/agent/tools.py
@@ -1,0 +1,168 @@
+"""Utility tool functions used by the agent.
+
+Each tool is a plain Python function so the agent can easily expose
+function-calling style interfaces to an LLM.  The implementations here are
+minimal stubs suitable for a prototype.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import requests
+from bs4 import BeautifulSoup
+from duckduckgo_search import DDGS
+import tweepy
+
+from .browser import login_and_run
+
+
+def web_search(query: str) -> str:
+    """Search the web via DuckDuckGo and return a short summary."""
+
+    results = []
+    with DDGS() as ddgs:
+        for res in ddgs.text(query, max_results=3):
+            title = res.get("title", "")
+            body = res.get("body", "")
+            results.append(f"{title}: {body}")
+    return "\n".join(results) if results else "no results found"
+
+
+def amazon_search(product: str) -> str:
+    """Fetch the first price for *product* from Amazon.
+
+    Uses a simple HTTP request and HTML scraping. Credentials are read from
+    environment variables ``AMAZON_USERNAME`` and ``AMAZON_PASSWORD``. The
+    login step here is only illustrative and may need adjustments for real
+    use.
+    """
+
+    session = requests.Session()
+    # Placeholder for an actual login flow using session.post(...)
+    _user = os.getenv("AMAZON_USERNAME")
+    _password = os.getenv("AMAZON_PASSWORD")
+    if not _user or not _password:
+        return "Amazon credentials not configured"
+
+    headers = {"User-Agent": "Mozilla/5.0"}
+    resp = session.get("https://www.amazon.com/s", params={"k": product}, headers=headers, timeout=10)
+    soup = BeautifulSoup(resp.text, "html.parser")
+    first = soup.select_one("div[data-component-type='s-search-result']")
+    if not first:
+        return "no results"
+    title = first.h2.get_text(strip=True)
+    price = first.select_one("span.a-price-whole")
+    price_text = price.get_text(strip=True) if price else "N/A"
+    return f"{title} - {price_text}"
+
+
+def twitter_post_tweet(message: str) -> str:
+    """Post ``message`` to Twitter using API credentials from ``.env``."""
+
+    api_key = os.getenv("TWITTER_API_KEY")
+    api_secret = os.getenv("TWITTER_API_SECRET")
+    access_token = os.getenv("TWITTER_ACCESS_TOKEN")
+    access_secret = os.getenv("TWITTER_ACCESS_SECRET")
+    if not all([api_key, api_secret, access_token, access_secret]):
+        return "Twitter credentials not configured"
+
+    auth = tweepy.OAuth1UserHandler(api_key, api_secret, access_token, access_secret)
+    api = tweepy.API(auth)
+    api.update_status(message)
+    return "tweet posted"
+
+
+def twitter_send_dm(username: str, message: str) -> str:
+    """Send a direct message to ``username`` with ``message``."""
+
+    api_key = os.getenv("TWITTER_API_KEY")
+    api_secret = os.getenv("TWITTER_API_SECRET")
+    access_token = os.getenv("TWITTER_ACCESS_TOKEN")
+    access_secret = os.getenv("TWITTER_ACCESS_SECRET")
+    if not all([api_key, api_secret, access_token, access_secret]):
+        return "Twitter credentials not configured"
+
+    auth = tweepy.OAuth1UserHandler(api_key, api_secret, access_token, access_secret)
+    api = tweepy.API(auth)
+    user = api.get_user(screen_name=username)
+    api.send_direct_message(user.id, message)
+    return "dm sent"
+
+
+def read_file(path: str) -> str:
+    """Read a text file.
+
+    This is a convenience wrapper around :class:`pathlib.Path` that ignores
+    errors and returns an empty string if the file does not exist.
+    """
+
+    p = Path(path)
+    return p.read_text() if p.exists() else ""
+
+
+def write_file(path: str, content: str) -> str:
+    """Write *content* to *path*.
+
+    Parameters
+    ----------
+    path:
+        Destination file path.
+    content:
+        Text content to write.
+
+    Returns
+    -------
+    str
+        Confirmation message.
+    """
+
+    Path(path).write_text(content)
+    return f"wrote {len(content)} characters"
+
+
+def browser_automation(
+    url: str,
+    user_env: str,
+    pass_env: str,
+    actions: Optional[List[Dict[str, str]]] = None,
+) -> str:
+    """Log into an arbitrary website and optionally perform extra actions.
+
+    Parameters
+    ----------
+    url:
+        Login page URL.
+    user_env, pass_env:
+        Names of environment variables holding the username and password.
+        **WARNING**: Never hard-code real credentials; use a secure store.
+    actions:
+        List of additional steps after login. Each step is a dictionary with
+        an ``action`` key (``goto``, ``click``, ``type`` or ``wait``).
+    """
+
+    username = os.getenv(user_env)
+    password = os.getenv(pass_env)
+    # WARNING: credentials must come from environment variables or a credential manager
+    if not username or not password:
+        return "credentials not configured"
+
+    return login_and_run(url, username, password, actions or [])
+
+
+def image_generate(prompt: str) -> str:
+    """Stub image generation function.
+
+    In a real system this would call out to an external image generation
+    service.  For now it only returns a textual acknowledgement.
+    """
+
+    return f"[image] would generate: {prompt}"
+
+
+def echo(text: str) -> str:
+    """Simple helper tool that just echoes text back."""
+
+    return text

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,72 @@
+"""Command line interface for service automation tools."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from dotenv import load_dotenv
+
+from agent.tools import (
+    amazon_search,
+    browser_automation,
+    twitter_post_tweet,
+    twitter_send_dm,
+    web_search,
+)
+
+
+def main() -> None:
+    """Entry point for the CLI.
+
+    Commands
+    --------
+    !websearch <query>
+        Run a DuckDuckGo search.
+    !amazon <product>
+        Search Amazon for a product and return the first price.
+    !twitter tweet <message>
+        Post a tweet with *message*.
+    !twitter dm <user> <message>
+        Send a DM to *user* with *message*.
+    !browse <url> <USER_ENV> <PASS_ENV> [actions_json]
+        Log into a website and optionally perform extra actions. ``actions_json``
+        is a JSON array describing follow-up steps.
+    """
+
+    load_dotenv()
+    command = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else input("> ").strip()
+
+    if command.startswith("!websearch"):
+        query = command[len("!websearch") :].strip()
+        print(web_search(query))
+    elif command.startswith("!amazon"):
+        product = command[len("!amazon") :].strip()
+        print(amazon_search(product))
+    elif command.startswith("!twitter"):
+        rest = command[len("!twitter") :].strip()
+        if rest.startswith("tweet"):
+            msg = rest[len("tweet") :].strip()
+            print(twitter_post_tweet(msg))
+        elif rest.startswith("dm"):
+            parts = rest.split(maxsplit=2)
+            if len(parts) < 3:
+                print("usage: !twitter dm <user> <message>")
+            else:
+                print(twitter_send_dm(parts[1], parts[2]))
+        else:
+            print("unknown twitter subcommand")
+    elif command.startswith("!browse"):
+        parts = command.split(maxsplit=4)
+        if len(parts) < 4:
+            print("usage: !browse <url> <USER_ENV> <PASS_ENV> [actions_json]")
+        else:
+            url, user_env, pass_env = parts[1:4]
+            actions = json.loads(parts[4]) if len(parts) > 4 else []
+            print(browser_automation(url, user_env, pass_env, actions))
+    else:
+        print("unknown command")
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,113 @@
+"""Minimal FastAPI application exposing the agent as an HTTP API."""
+
+from __future__ import annotations
+
+import os
+from typing import List
+
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+from dotenv import load_dotenv
+
+from agent.llm import LLMClient, Step
+from agent.planner import plan_task
+from agent.executor import execute_plan
+from agent.tools import (
+    amazon_search,
+    browser_automation,
+    twitter_post_tweet,
+    twitter_send_dm,
+    web_search,
+)
+load_dotenv()
+app = FastAPI(title="ORALLM Agent")
+
+
+class TaskRequest(BaseModel):
+    """Request schema for the `/tasks` endpoint."""
+
+    instruction: str
+
+
+class TaskResponse(BaseModel):
+    """Response schema returned after executing a task."""
+
+    plan: List[Step]
+    results: List[str]
+
+
+llm_client = LLMClient(
+    provider=os.getenv("LLM_PROVIDER"),
+    api_key=os.getenv("LLM_API_KEY"),
+    model_path=os.getenv("LLM_MODEL_PATH"),
+)
+
+
+@app.post("/tasks", response_model=TaskResponse)
+def run_task(req: TaskRequest) -> TaskResponse:
+    """Create a plan for ``req.instruction`` and execute it."""
+
+    plan = plan_task(req.instruction, llm_client)
+    results = execute_plan(plan, llm_client)
+    return TaskResponse(plan=plan, results=results)
+
+
+@app.get("/websearch")
+def api_websearch(q: str) -> str:
+    """Run a DuckDuckGo search for ``q``."""
+
+    return web_search(q)
+
+
+@app.get("/amazon")
+def api_amazon(q: str) -> str:
+    """Search Amazon for ``q`` and return the first price."""
+
+    return amazon_search(q)
+
+
+class TweetRequest(BaseModel):
+    """Schema for posting a tweet."""
+
+    message: str
+
+
+@app.post("/twitter/tweet")
+def api_twitter_tweet(req: TweetRequest) -> dict:
+    """Post ``req.message`` to Twitter."""
+
+    return {"status": twitter_post_tweet(req.message)}
+
+
+class DMRequest(BaseModel):
+    """Schema for sending a direct message."""
+
+    user: str
+    message: str
+
+
+@app.post("/twitter/dm")
+def api_twitter_dm(req: DMRequest) -> dict:
+    """Send a DM to ``req.user``."""
+
+    return {"status": twitter_send_dm(req.user, req.message)}
+
+
+class BrowserRequest(BaseModel):
+    """Schema for generic browser automation."""
+
+    url: str
+    user_env: str
+    pass_env: str
+    actions: List[dict] = Field(default_factory=list)
+
+
+@app.post("/browser")
+def api_browser(req: BrowserRequest) -> dict:
+    """Log into a site and optionally perform extra actions."""
+
+    return {
+        "status": browser_automation(
+            req.url, req.user_env, req.pass_env, req.actions
+        )
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+fastapi
+uvicorn
+beautifulsoup4
+duckduckgo-search
+openai
+python-dotenv
+requests
+selenium
+tweepy
+playwright
+llama-cpp-python

--- a/run_agent.ps1
+++ b/run_agent.ps1
@@ -1,0 +1,11 @@
+<#!
+.SYNOPSIS
+    Start the ORALLM agent API using the local virtual environment.
+#>
+param(
+    [int]$Port = 8000
+)
+$ErrorActionPreference = "Stop"
+$root = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$venv = Join-Path $root ".venv"
+& "$venv\\Scripts\\uvicorn.exe" main:app --host 0.0.0.0 --port $Port

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,0 +1,52 @@
+<#!
+.SYNOPSIS
+    Set up a disposable Windows environment for the ORALLM agent.
+.DESCRIPTION
+    - Installs Python (using winget) if missing
+    - Clones the ORALLMAgent repository
+    - Creates a virtual environment and installs dependencies
+    - Generates a blank .env file for later secrets
+    The script assumes a Windows 10/11 VM with ~4 CPU cores, 30GB disk and
+    10GB RAM.
+#>
+param(
+    [string]$RepoUrl = "https://github.com/ORALLMAgent/ORALLMAgent.git",
+    [string]$InstallDir = "$env:USERPROFILE\\orallm_agent"
+)
+$ErrorActionPreference = "Stop"
+
+# Install Python if not available
+if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
+    Write-Host "Python not found. Installing via winget..."
+    winget install -e --id Python.Python.3.11 --source winget -h
+}
+
+# Clone or update repository
+if (-not (Test-Path $InstallDir)) {
+    git clone $RepoUrl $InstallDir
+} else {
+    Write-Host "Repository already exists. Pulling latest changes..."
+    git -C $InstallDir pull
+}
+
+# Create virtual environment
+$venv = Join-Path $InstallDir ".venv"
+if (-not (Test-Path $venv)) {
+    python -m venv $venv
+}
+
+# Install dependencies
+& "$venv\\Scripts\\pip.exe" install --upgrade pip
+& "$venv\\Scripts\\pip.exe" install -r (Join-Path $InstallDir "requirements.txt")
+& "$venv\\Scripts\\python.exe" -m playwright install
+
+# Prepare .env file
+$envFile = Join-Path $InstallDir ".env"
+if (-not (Test-Path $envFile)) {
+    Copy-Item (Join-Path $InstallDir ".env.example") $envFile
+    Write-Host "Created template .env at $envFile"
+}
+
+Write-Host "Setup complete. Activate the environment with:"
+Write-Host "`t$venv\\Scripts\\activate"
+Write-Host "Then run: uvicorn main:app --host 0.0.0.0 --port 8000"


### PR DESCRIPTION
## Summary
- support Playwright-driven login and action sequences for arbitrary sites via CLI and API
- allow selecting local LLMs such as llama.cpp through environment configuration
- document credential safety and include setup steps for Playwright

## Testing
- `python -m py_compile $(find . -name '*.py')`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f87c6c48883228dcd3f655a6db20d