### PR TITLE
feat: add generic browser automation and local llm options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# Provider for LLM operations (e.g. openai, anthropic, stub)
+LLM_PROVIDER=stub
+# API key for the chosen LLM provider
+LLM_API_KEY=
+# Optional path to a local llama.cpp model
+LLAMA_MODEL_PATH=
+# Optional Hugging Face model name for transformers backend
+HF_MODEL_NAME=
+
+# Amazon credentials
+AMAZON_USERNAME=
+AMAZON_PASSWORD=
+
+# Twitter credentials
+TWITTER_API_KEY=
+TWITTER_API_SECRET=
+TWITTER_ACCESS_TOKEN=
+TWITTER_ACCESS_SECRET=
+
+# Example credentials for a generic site
+EXAMPLE_USERNAME=
+EXAMPLE_PASSWORD=

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Provider for LLM operations (e.g. openai, api, stub)
+# Provider for LLM operations (e.g. openai, anthropic, api, stub)
 LLM_PROVIDER=stub
 # Base URL of the local LLM API server when using the `api` provider
 LLM_API_URL=http://127.0.0.1:8000

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
-# Provider for LLM operations (e.g. openai, anthropic, stub)
+# Provider for LLM operations (e.g. openai, api, stub)
 LLM_PROVIDER=stub
+# Base URL of the local LLM API server when using the `api` provider
+LLM_API_URL=http://127.0.0.1:8000
 # API key for the chosen LLM provider
 LLM_API_KEY=
 # Optional path to a local llama.cpp model

--- a/README.md
+++ b/README.md
@@ -1,2 +1,83 @@
 # ORALLMAgent
-Agent
+
+Minimal prototype of an autonomous task execution system inspired by projects
+like Manus.  The goal is to demonstrate a clean API surface that can later be
+extended to chat bots, web apps or mobile clients.
+
+## Features
+
+* Accepts natural language instructions via an HTTP API.
+* Asks an LLM to produce an execution plan.
+* Executes the plan step by step using simple tool functions.
+* Built‑in tools for web search, Amazon price lookup and Twitter automation.
+* Generic browser automation powered by Playwright for logging into arbitrary
+  web sites and performing actions in a human‑like manner.
+* Command line interface with ``!websearch``, ``!amazon``, ``!twitter`` and
+  ``!browser`` commands.
+* Pluggable LLM backend: choose OpenAI, a local ``llama.cpp`` model or any
+  ``transformers`` model via environment variables.
+* After each step the LLM can perform a short reflection.
+* The architecture separates planning, execution and the HTTP layer which makes
+  it easy to integrate the core logic elsewhere.
+
+## Usage
+
+```bash
+pip install -r requirements.txt
+python -m playwright install  # installs browser drivers
+uvicorn main:app --reload
+```
+
+Then send a request:
+
+```bash
+curl -X POST http://localhost:8000/tasks -H "Content-Type: application/json" \
+    -d '{"instruction": "write hello to test.txt"}'
+```
+
+Without an API key the system falls back to deterministic behaviour which keeps
+it functional for local experiments.
+
+### Windows quick start
+
+The repository ships with a PowerShell script that installs Python (via
+``winget``), clones this repository, prepares a virtual environment and installs
+all dependencies.  Run the following from an elevated PowerShell prompt:
+
+```powershell
+Set-ExecutionPolicy Bypass -Scope Process -Force
+./setup.ps1
+```
+
+After setup, start the API using:
+
+```powershell
+./run_agent.ps1
+```
+
+Environment variables such as API keys can be stored in a ``.env`` file.  A
+``.env.example`` template is provided for convenience.  **Never commit real
+credentials to source control.**  Store API keys and passwords in ``.env`` or
+the Windows credential manager.
+
+### Security notes
+
+Credentials must never be hardcoded.  Populate the ``.env`` file or the
+credential manager and reference variables from automation steps using the
+``env`` field.  The browser tool intentionally stops when CAPTCHA or two‑factor
+authentication is detected so the user can intervene manually.
+
+### Command line usage
+
+The ``cli.py`` helper exposes a very small command interface:
+
+```bash
+python cli.py "!websearch sushi"
+python cli.py "!amazon raspberry pi"
+python cli.py "!twitter tweet hello world"
+python cli.py "!browser https://example.com '[{"action":"click","selector":"#login"}]'"
+```
+
+Twitter commands require API credentials.  Amazon scraping is intended for
+simple experiments and may need adjustments to comply with Amazon's terms of
+service.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ extended to chat bots, web apps or mobile clients.
   web sites and performing actions in a human‑like manner.
 * Command line interface with ``!websearch``, ``!amazon``, ``!twitter`` and
   ``!browser`` commands.
-* Pluggable LLM backend: choose OpenAI, a local ``llama.cpp`` model or any
-  ``transformers`` model via environment variables.
+* Pluggable LLM backend: choose OpenAI, a local ``llama.cpp`` model, any
+  ``transformers`` model or a custom API served on localhost/LAN.
 * After each step the LLM can perform a short reflection.
 * The architecture separates planning, execution and the HTTP layer which makes
   it easy to integrate the core logic elsewhere.
@@ -59,6 +59,15 @@ Environment variables such as API keys can be stored in a ``.env`` file.  A
 ``.env.example`` template is provided for convenience.  **Never commit real
 credentials to source control.**  Store API keys and passwords in ``.env`` or
 the Windows credential manager.
+
+### Local LLM API
+
+The agent can delegate all model inference to an LLM API server running on
+the host machine.  Start your preferred server (e.g. ``llama.cpp`` with an
+HTTP wrapper) and expose it on ``127.0.0.1`` or a trusted LAN address.  In the
+``.env`` file set ``LLM_PROVIDER=api`` and point ``LLM_API_URL`` to the server
+URL.  Optionally provide ``LLM_API_KEY`` if the server requires authentication.
+**Do not expose the API to the public internet.**
 
 ### Security notes
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ URL.  Optionally provide ``LLM_API_KEY`` if the server requires authentication.
 
 Credentials must never be hardcoded.  Populate the ``.env`` file or the
 credential manager and reference variables from automation steps using the
-``env`` field.  The browser tool intentionally stops when CAPTCHA or two‑factor
+``env`` field.  The browser tool intentionally stops when CAPTCHA or two-factor
 authentication is detected so the user can intervene manually.
 
 ### Command line usage
@@ -84,7 +84,7 @@ The ``cli.py`` helper exposes a very small command interface:
 python cli.py "!websearch sushi"
 python cli.py "!amazon raspberry pi"
 python cli.py "!twitter tweet hello world"
-python cli.py "!browser https://example.com '[{"action":"click","selector":"#login"}]'"
+python cli.py "!browser https://example.com '[{\"action\":\"click\",\"selector\":\"#login\"}]'"
 ```
 
 Twitter commands require API credentials.  Amazon scraping is intended for

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,1 @@
+"""Core modules for the ORALLM agent prototype."""

--- a/agent/executor.py
+++ b/agent/executor.py
@@ -1,0 +1,34 @@
+"""Plan execution utilities."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+from .llm import LLMClient, Step
+from . import tools
+
+# Mapping from tool names to callables.  New tools can be registered here
+# without having to touch the execution logic itself.
+TOOL_REGISTRY = {
+    "web_search": tools.web_search,
+    "read_file": tools.read_file,
+    "write_file": tools.write_file,
+    "image_generate": tools.image_generate,
+    "browser_action": tools.browser_action,
+    "echo": tools.echo,
+}
+
+
+def execute_plan(plan: Iterable[Step], llm: LLMClient) -> List[str]:
+    """Execute *plan* sequentially using *llm* for optional reflection."""
+
+    results: List[str] = []
+    for step in plan:
+        func = TOOL_REGISTRY.get(step.tool)
+        if not func:
+            results.append(f"unknown tool: {step.tool}")
+            continue
+        result = func(**step.args)
+        results.append(result)
+        llm.reflect(result)
+    return results

--- a/agent/llm.py
+++ b/agent/llm.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 import os
+import requests
 
 try:  # Optional import; the package may not be installed.
     import openai  # type: ignore
@@ -43,6 +44,7 @@ class LLMClient:
     def __init__(self, provider: Optional[str] = None, api_key: Optional[str] = None) -> None:
         self.provider = provider or os.getenv("LLM_PROVIDER", "stub")
         self.api_key = api_key or os.getenv("LLM_API_KEY") or os.getenv("OPENAI_API_KEY")
+        self.api_url = os.getenv("LLM_API_URL")
         # Optional backends for local models
         self._llama = None
         self._pipe = None
@@ -73,6 +75,19 @@ class LLMClient:
             )
             plan_text: str = response["choices"][0]["message"]["content"]  # type: ignore[index]
             return [Step(tool="echo", args={"text": plan_text}, description="raw plan")]
+        if self.provider == "api" and self.api_url:
+            headers = {}
+            if self.api_key:
+                headers["Authorization"] = f"Bearer {self.api_key}"
+            try:
+                resp = requests.post(self.api_url, json={"prompt": f"Plan steps to: {instruction}"}, headers=headers, timeout=60)
+                resp.raise_for_status()
+                data = resp.json()
+                plan_text = data.get("text") or data.get("output") or ""
+                if plan_text:
+                    return [Step(tool="echo", args={"text": plan_text}, description="raw plan")]
+            except Exception:
+                pass
         if self.provider == "llama_cpp" and self._llama is not None:
             output = self._llama(f"Plan steps to: {instruction}", max_tokens=128)
             plan_text = output["choices"][0]["text"]  # type: ignore[index]
@@ -105,6 +120,17 @@ class LLMClient:
                 messages=[{"role": "user", "content": f"Reflect on: {result}"}],
             )
             return response["choices"][0]["message"]["content"]  # type: ignore[index]
+        if self.provider == "api" and self.api_url:
+            headers = {}
+            if self.api_key:
+                headers["Authorization"] = f"Bearer {self.api_key}"
+            try:
+                resp = requests.post(self.api_url, json={"prompt": f"Reflect on: {result}"}, headers=headers, timeout=60)
+                resp.raise_for_status()
+                data = resp.json()
+                return data.get("text") or data.get("output") or result
+            except Exception:
+                return result
         if self.provider == "llama_cpp" and self._llama is not None:
             output = self._llama(f"Reflect on: {result}", max_tokens=64)
             return output["choices"][0]["text"]  # type: ignore[index]

--- a/agent/llm.py
+++ b/agent/llm.py
@@ -1,0 +1,113 @@
+"""LLM helper utilities.
+
+The real system would talk to OpenAI, Anthropic or a local model.  The
+implementation below keeps the interface but falls back to deterministic
+responses when no API key is provided.  This keeps the prototype fully
+functional in offline environments.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+import os
+
+try:  # Optional import; the package may not be installed.
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - we do not want tests to fail here
+    openai = None  # type: ignore
+
+try:
+    from llama_cpp import Llama  # type: ignore
+except Exception:  # pragma: no cover
+    Llama = None  # type: ignore
+
+try:
+    from transformers import pipeline  # type: ignore
+except Exception:  # pragma: no cover
+    pipeline = None  # type: ignore
+
+
+@dataclass
+class Step:
+    """Simple representation of an execution step planned by the LLM."""
+
+    tool: str
+    args: Dict[str, Any]
+    description: str
+
+
+class LLMClient:
+    """Very small wrapper around an LLM provider."""
+
+    def __init__(self, provider: Optional[str] = None, api_key: Optional[str] = None) -> None:
+        self.provider = provider or os.getenv("LLM_PROVIDER", "stub")
+        self.api_key = api_key or os.getenv("LLM_API_KEY") or os.getenv("OPENAI_API_KEY")
+        # Optional backends for local models
+        self._llama = None
+        self._pipe = None
+        if self.provider == "llama_cpp" and Llama:
+            model_path = os.getenv("LLAMA_MODEL_PATH")
+            if model_path:
+                self._llama = Llama(model_path=model_path)
+        elif self.provider == "transformers" and pipeline:
+            model_name = os.getenv("HF_MODEL_NAME", "gpt2")
+            try:
+                self._pipe = pipeline("text-generation", model=model_name)
+            except Exception:
+                self._pipe = None
+
+    # ------------------------------------------------------------------
+    def plan(self, instruction: str) -> List[Step]:
+        """Create a naive execution plan for *instruction*.
+
+        The real implementation would send the request to the configured LLM
+        provider.  If no provider is configured we return a deterministic plan
+        so that the rest of the system can be exercised.
+        """
+
+        if self.provider == "openai" and self.api_key and openai is not None:
+            response = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": f"Plan steps to: {instruction}"}],
+            )
+            plan_text: str = response["choices"][0]["message"]["content"]  # type: ignore[index]
+            return [Step(tool="echo", args={"text": plan_text}, description="raw plan")]
+        if self.provider == "llama_cpp" and self._llama is not None:
+            output = self._llama(f"Plan steps to: {instruction}", max_tokens=128)
+            plan_text = output["choices"][0]["text"]  # type: ignore[index]
+            return [Step(tool="echo", args={"text": plan_text}, description="raw plan")]
+        if self.provider == "transformers" and self._pipe is not None:
+            plan_text = self._pipe(f"Plan steps to: {instruction}")[0]["generated_text"]
+            return [Step(tool="echo", args={"text": plan_text}, description="raw plan")]
+        # Fallback stub implementation
+        if not self.api_key or self.provider == "stub":
+            return [
+                Step(
+                    tool="echo",
+                    args={"text": f"LLM unavailable. Instruction was: {instruction}"},
+                    description="echo fallback",
+                )
+            ]
+        return [Step(tool="echo", args={"text": "LLM provider unavailable"}, description="error")]
+
+    # ------------------------------------------------------------------
+    def reflect(self, result: str) -> str:
+        """Allow the LLM to reflect on the latest *result*.
+
+        When the provider is not available we simply return the original
+        result.  This keeps the call synchronous for easier reasoning.
+        """
+
+        if self.provider == "openai" and self.api_key and openai is not None:
+            response = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": f"Reflect on: {result}"}],
+            )
+            return response["choices"][0]["message"]["content"]  # type: ignore[index]
+        if self.provider == "llama_cpp" and self._llama is not None:
+            output = self._llama(f"Reflect on: {result}", max_tokens=64)
+            return output["choices"][0]["text"]  # type: ignore[index]
+        if self.provider == "transformers" and self._pipe is not None:
+            return self._pipe(f"Reflect on: {result}")[0]["generated_text"]
+        return result

--- a/agent/planner.py
+++ b/agent/planner.py
@@ -1,0 +1,13 @@
+"""High level planning helpers."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .llm import LLMClient, Step
+
+
+def plan_task(instruction: str, llm: LLMClient) -> List[Step]:
+    """Ask *llm* to create a plan for *instruction*."""
+
+    return llm.plan(instruction)

--- a/agent/tools.py
+++ b/agent/tools.py
@@ -19,7 +19,6 @@ import tweepy
 # Browser automation imports are optional; Playwright is heavy and may not be
 # installed in minimal environments.  Import lazily inside the function.
 
-
 def web_search(query: str) -> str:
     """Search the web via DuckDuckGo and return a short summary."""
 

--- a/agent/tools.py
+++ b/agent/tools.py
@@ -1,0 +1,204 @@
+"""Utility tool functions used by the agent.
+
+Each tool is a plain Python function so the agent can easily expose
+function-calling style interfaces to an LLM.  The implementations here are
+minimal stubs suitable for a prototype.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, List, Dict
+
+import requests
+from bs4 import BeautifulSoup
+from duckduckgo_search import DDGS
+import tweepy
+
+# Browser automation imports are optional; Playwright is heavy and may not be
+# installed in minimal environments.  Import lazily inside the function.
+
+
+def web_search(query: str) -> str:
+    """Search the web via DuckDuckGo and return a short summary."""
+
+    results = []
+    with DDGS() as ddgs:
+        for res in ddgs.text(query, max_results=3):
+            title = res.get("title", "")
+            body = res.get("body", "")
+            results.append(f"{title}: {body}")
+    return "\n".join(results) if results else "no results found"
+
+
+def amazon_search(product: str) -> str:
+    """Fetch the first price for *product* from Amazon.
+
+    Uses a simple HTTP request and HTML scraping. Credentials are read from
+    environment variables ``AMAZON_USERNAME`` and ``AMAZON_PASSWORD``. The
+    login step here is only illustrative and may need adjustments for real
+    use.
+    """
+
+    session = requests.Session()
+    # Placeholder for an actual login flow using session.post(...)
+    _user = os.getenv("AMAZON_USERNAME")
+    _password = os.getenv("AMAZON_PASSWORD")
+    if not _user or not _password:
+        return "Amazon credentials not configured"
+
+    headers = {"User-Agent": "Mozilla/5.0"}
+    resp = session.get("https://www.amazon.com/s", params={"k": product}, headers=headers, timeout=10)
+    soup = BeautifulSoup(resp.text, "html.parser")
+    first = soup.select_one("div[data-component-type='s-search-result']")
+    if not first:
+        return "no results"
+    title = first.h2.get_text(strip=True)
+    price = first.select_one("span.a-price-whole")
+    price_text = price.get_text(strip=True) if price else "N/A"
+    return f"{title} - {price_text}"
+
+
+def twitter_post_tweet(message: str) -> str:
+    """Post ``message`` to Twitter using API credentials from ``.env``."""
+
+    api_key = os.getenv("TWITTER_API_KEY")
+    api_secret = os.getenv("TWITTER_API_SECRET")
+    access_token = os.getenv("TWITTER_ACCESS_TOKEN")
+    access_secret = os.getenv("TWITTER_ACCESS_SECRET")
+    if not all([api_key, api_secret, access_token, access_secret]):
+        return "Twitter credentials not configured"
+
+    auth = tweepy.OAuth1UserHandler(api_key, api_secret, access_token, access_secret)
+    api = tweepy.API(auth)
+    api.update_status(message)
+    return "tweet posted"
+
+
+def twitter_send_dm(username: str, message: str) -> str:
+    """Send a direct message to ``username`` with ``message``."""
+
+    api_key = os.getenv("TWITTER_API_KEY")
+    api_secret = os.getenv("TWITTER_API_SECRET")
+    access_token = os.getenv("TWITTER_ACCESS_TOKEN")
+    access_secret = os.getenv("TWITTER_ACCESS_SECRET")
+    if not all([api_key, api_secret, access_token, access_secret]):
+        return "Twitter credentials not configured"
+
+    auth = tweepy.OAuth1UserHandler(api_key, api_secret, access_token, access_secret)
+    api = tweepy.API(auth)
+    user = api.get_user(screen_name=username)
+    api.send_direct_message(user.id, message)
+    return "dm sent"
+
+
+def read_file(path: str) -> str:
+    """Read a text file.
+
+    This is a convenience wrapper around :class:`pathlib.Path` that ignores
+    errors and returns an empty string if the file does not exist.
+    """
+
+    p = Path(path)
+    return p.read_text() if p.exists() else ""
+
+
+def write_file(path: str, content: str) -> str:
+    """Write *content* to *path*.
+
+    Parameters
+    ----------
+    path:
+        Destination file path.
+    content:
+        Text content to write.
+
+    Returns
+    -------
+    str
+        Confirmation message.
+    """
+
+    Path(path).write_text(content)
+    return f"wrote {len(content)} characters"
+
+
+def image_generate(prompt: str) -> str:
+    """Stub image generation function.
+
+    In a real system this would call out to an external image generation
+    service.  For now it only returns a textual acknowledgement.
+    """
+
+    return f"[image] would generate: {prompt}"
+
+
+def browser_action(url: str, steps: List[Dict[str, Any]]) -> str:
+    """Automate a sequence of browser interactions using Playwright.
+
+    SECURITY WARNING: Do not hardcode credentials in code.  Provide secrets via
+    environment variables or the Windows credential manager.  This function is
+    intentionally simple and does not attempt to bypass CAPTCHA or two-factor
+    authentication; if such mechanisms are detected the caller should prompt
+    the user for manual input.
+
+    Parameters
+    ----------
+    url:
+        Initial URL to open.
+    steps:
+        List of action dictionaries.  Supported keys:
+
+        ``action``
+            One of ``goto``, ``click``, ``type`` or ``wait``.
+        ``selector``
+            CSS selector used for ``click``/``type``/``wait`` actions.
+        ``text``
+            Literal text to type for ``type`` actions.
+        ``env``
+            Name of an environment variable whose value will be typed instead of
+            ``text``.
+
+    Returns
+    -------
+    str
+        Status message describing the outcome.
+    """
+
+    import random
+    import time
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context()
+        page = context.new_page()
+        page.goto(url)
+        for step in steps:
+            action = step.get("action")
+            if action == "goto":
+                page.goto(step["url"])
+            elif action == "click":
+                page.click(step["selector"], delay=random.randint(50, 150))
+            elif action == "type":
+                value = step.get("text", "")
+                env_name = step.get("env")
+                if env_name:
+                    value = os.getenv(env_name, "")
+                page.click(step["selector"])
+                page.type(step["selector"], value, delay=random.randint(50, 150))
+            elif action == "wait":
+                page.wait_for_selector(step["selector"], timeout=step.get("timeout", 5000))
+            time.sleep(random.uniform(0.2, 0.5))
+        content = page.content().lower()
+        browser.close()
+    if "captcha" in content or "two-factor" in content:
+        return "manual intervention required"
+    return "browser actions completed"
+
+
+def echo(text: str) -> str:
+    """Simple helper tool that just echoes text back."""
+
+    return text

--- a/cli.py
+++ b/cli.py
@@ -47,6 +47,7 @@ def main() -> None:
             print("usage: !browser <url> <json_steps>")
         else:
             import json
+
             url = parts[1]
             steps = json.loads(parts[2])
             print(browser_action(url, steps))

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,71 @@
+"""Command line interface for service automation tools."""
+
+from __future__ import annotations
+
+import sys
+
+from dotenv import load_dotenv
+
+from agent.tools import (
+    amazon_search,
+    browser_action,
+    twitter_post_tweet,
+    twitter_send_dm,
+    web_search,
+)
+
+
+def main() -> None:
+    """Entry point for the CLI.
+
+    Commands
+    --------
+    !websearch <query>
+        Run a DuckDuckGo search.
+    !amazon <product>
+        Search Amazon for a product and return the first price.
+    !twitter tweet <message>
+        Post a tweet with *message*.
+    !twitter dm <user> <message>
+        Send a DM to *user* with *message*.
+    !browser <url> <json_steps>
+        Execute browser automation steps described by JSON.
+    """
+
+    load_dotenv()
+    command = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else input("> ").strip()
+
+    if command.startswith("!websearch"):
+        query = command[len("!websearch") :].strip()
+        print(web_search(query))
+    elif command.startswith("!amazon"):
+        product = command[len("!amazon") :].strip()
+        print(amazon_search(product))
+    elif command.startswith("!browser"):
+        parts = command.split(maxsplit=2)
+        if len(parts) < 3:
+            print("usage: !browser <url> <json_steps>")
+        else:
+            import json
+            url = parts[1]
+            steps = json.loads(parts[2])
+            print(browser_action(url, steps))
+    elif command.startswith("!twitter"):
+        rest = command[len("!twitter") :].strip()
+        if rest.startswith("tweet"):
+            msg = rest[len("tweet") :].strip()
+            print(twitter_post_tweet(msg))
+        elif rest.startswith("dm"):
+            parts = rest.split(maxsplit=2)
+            if len(parts) < 3:
+                print("usage: !twitter dm <user> <message>")
+            else:
+                print(twitter_send_dm(parts[1], parts[2]))
+        else:
+            print("unknown twitter subcommand")
+    else:
+        print("unknown command")
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ from agent.tools import (
     twitter_send_dm,
     web_search,
 )
+
 load_dotenv()
 app = FastAPI(title="ORALLM Agent")
 

--- a/main.py
+++ b/main.py
@@ -1,0 +1,101 @@
+"""Minimal FastAPI application exposing the agent as an HTTP API."""
+
+from __future__ import annotations
+
+import os
+from typing import List
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+from dotenv import load_dotenv
+
+from agent.llm import LLMClient, Step
+from agent.planner import plan_task
+from agent.executor import execute_plan
+from agent.tools import (
+    amazon_search,
+    browser_action,
+    twitter_post_tweet,
+    twitter_send_dm,
+    web_search,
+)
+load_dotenv()
+app = FastAPI(title="ORALLM Agent")
+
+
+class TaskRequest(BaseModel):
+    """Request schema for the `/tasks` endpoint."""
+
+    instruction: str
+
+
+class TaskResponse(BaseModel):
+    """Response schema returned after executing a task."""
+
+    plan: List[Step]
+    results: List[str]
+
+
+llm_client = LLMClient(provider=os.getenv("LLM_PROVIDER"), api_key=os.getenv("LLM_API_KEY"))
+
+
+@app.post("/tasks", response_model=TaskResponse)
+def run_task(req: TaskRequest) -> TaskResponse:
+    """Create a plan for ``req.instruction`` and execute it."""
+
+    plan = plan_task(req.instruction, llm_client)
+    results = execute_plan(plan, llm_client)
+    return TaskResponse(plan=plan, results=results)
+
+
+@app.get("/websearch")
+def api_websearch(q: str) -> str:
+    """Run a DuckDuckGo search for ``q``."""
+
+    return web_search(q)
+
+
+@app.get("/amazon")
+def api_amazon(q: str) -> str:
+    """Search Amazon for ``q`` and return the first price."""
+
+    return amazon_search(q)
+
+
+class TweetRequest(BaseModel):
+    """Schema for posting a tweet."""
+
+    message: str
+
+
+@app.post("/twitter/tweet")
+def api_twitter_tweet(req: TweetRequest) -> dict:
+    """Post ``req.message`` to Twitter."""
+
+    return {"status": twitter_post_tweet(req.message)}
+
+
+class DMRequest(BaseModel):
+    """Schema for sending a direct message."""
+
+    user: str
+    message: str
+
+
+@app.post("/twitter/dm")
+def api_twitter_dm(req: DMRequest) -> dict:
+    """Send a DM to ``req.user``."""
+
+    return {"status": twitter_send_dm(req.user, req.message)}
+
+
+class BrowserRequest(BaseModel):
+    url: str
+    steps: list
+
+
+@app.post("/browser")
+def api_browser(req: BrowserRequest) -> dict:
+    """Execute browser automation steps."""
+
+    return {"status": browser_action(req.url, req.steps)}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+fastapi
+uvicorn
+beautifulsoup4
+duckduckgo-search
+openai
+python-dotenv
+requests
+selenium
+tweepy
+playwright
+llama-cpp-python
+transformers

--- a/run_agent.ps1
+++ b/run_agent.ps1
@@ -1,0 +1,11 @@
+<#!
+.SYNOPSIS
+    Start the ORALLM agent API using the local virtual environment.
+#>
+param(
+    [int]$Port = 8000
+)
+$ErrorActionPreference = "Stop"
+$root = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$venv = Join-Path $root ".venv"
+& "$venv\\Scripts\\uvicorn.exe" main:app --host 0.0.0.0 --port $Port

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,0 +1,53 @@
+<#!
+.SYNOPSIS
+    Set up a disposable Windows environment for the ORALLM agent.
+.DESCRIPTION
+    - Installs Python (using winget) if missing
+    - Clones the ORALLMAgent repository
+    - Creates a virtual environment and installs dependencies
+    - Generates a blank .env file for later secrets
+    The script assumes a Windows 10/11 VM with ~4 CPU cores, 30GB disk and
+    10GB RAM.
+#>
+param(
+    [string]$RepoUrl = "https://github.com/ORALLMAgent/ORALLMAgent.git",
+    [string]$InstallDir = "$env:USERPROFILE\\orallm_agent"
+)
+$ErrorActionPreference = "Stop"
+
+# Install Python if not available
+if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
+    Write-Host "Python not found. Installing via winget..."
+    winget install -e --id Python.Python.3.11 --source winget -h
+}
+
+# Clone or update repository
+if (-not (Test-Path $InstallDir)) {
+    git clone $RepoUrl $InstallDir
+} else {
+    Write-Host "Repository already exists. Pulling latest changes..."
+    git -C $InstallDir pull
+}
+
+# Create virtual environment
+$venv = Join-Path $InstallDir ".venv"
+if (-not (Test-Path $venv)) {
+    python -m venv $venv
+}
+
+# Install dependencies
+& "$venv\\Scripts\\pip.exe" install --upgrade pip
+& "$venv\\Scripts\\pip.exe" install -r (Join-Path $InstallDir "requirements.txt")
+# Install browser drivers for Playwright
+& "$venv\\Scripts\\python.exe" -m playwright install chromium
+
+# Prepare .env file
+$envFile = Join-Path $InstallDir ".env"
+if (-not (Test-Path $envFile)) {
+    Copy-Item (Join-Path $InstallDir ".env.example") $envFile
+    Write-Host "Created template .env at $envFile"
+}
+
+Write-Host "Setup complete. Activate the environment with:"
+Write-Host "`t$venv\\Scripts\\activate"
+Write-Host "Then run: uvicorn main:app --host 0.0.0.0 --port 8000"


### PR DESCRIPTION
## Summary
- automate arbitrary websites via Playwright with a browser_action tool and CLI/API hooks
- allow choosing OpenAI, llama.cpp, or transformers backends through environment variables
- document security practices and install browser drivers during setup

## Testing
- `python3 -m pytest`
- `python3 -m py_compile $(find . -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688f87c6c48883228dcd3f655a6db20d